### PR TITLE
Clarify the data type of the first input of Struct().unpack method

### DIFF
--- a/spc/global_fun.py
+++ b/spc/global_fun.py
@@ -37,7 +37,7 @@ def read_subheader(subheader):
     """
 
     subhead_str = "<cchfffiif4s"
-    items = struct.unpack(subhead_str, subheader)
+    items = struct.unpack(unicode(subhead_str).encode('utf8'), subheader)
 
     item_cpy = [ord(i) for i in items[:2]]
     item_cpy += items[2:]

--- a/spc/spc.py
+++ b/spc/spc.py
@@ -57,7 +57,7 @@ class File:
 
         self.length = len(content)
         # extract first two bytes to determine file type version
-        self.ftflg, self.fversn = struct.unpack('<cc', content[:2])
+        self.ftflg, self.fversn = struct.unpack(unicode('<cc').encode('utf8'), content[:2])
         # --------------------------------------------
         # NEW FORMAT (LSB)
         # --------------------------------------------
@@ -99,7 +99,7 @@ class File:
                 self.fwinc, \
                 self.fwtype, \
                 self.freserv \
-                = struct.unpack(self.head_str, content[:self.head_siz])
+                = struct.unpack(unicode(self.head_str).encode('utf8'), content[:self.head_siz])
 
             # Flag bits
             self.tsprec, \
@@ -181,7 +181,7 @@ class File:
                 # loop over entries in directory
                 for i in range(0, self.fnsub):
                     ssfposn, ssfsize, ssftime = struct.unpack(
-                        '<iif', content[self.fnpts + (i * 12):self.fnpts + ((i + 1) * 12)])
+                        unicode('<iif').encode('utf8'), content[self.fnpts + (i * 12):self.fnpts + ((i + 1) * 12)])
                     # add sufile, load defaults for npts and exp
                     self.sub.append(subFile(content[ssfposn:ssfposn + ssfsize], 0, 0, True, self.tsprec))
 
@@ -217,7 +217,7 @@ class File:
                     self.logbins, \
                     self.logdsks, \
                     self.logspar \
-                    = struct.unpack(self.logstc_str,
+                    = struct.unpack(unicode(self.logstc_str).encode('utf8'),
                                     content[self.flogoff:log_head_end])
                 log_pos = self.flogoff + self.logtxto
 
@@ -278,7 +278,7 @@ class File:
                 self.ospare, \
                 self.ocmnt, \
                 self.ocatxt, \
-                self.osubh1 = struct.unpack(self.old_head_str,
+                self.osubh1 = struct.unpack(unicode(self.old_head_str).encode('utf8'),
                                             content[:self.old_head_siz])
 
             # Flag bits (assuming same)
@@ -380,8 +380,8 @@ class File:
                 if raw_data[i:i + 8] != s_8:
                     break
             dat_siz = int(dat_len / 8)
-            self.y = struct.unpack('<' + dat_siz * 'd', raw_data[:dat_len])
-            self.x = struct.unpack('<' + dat_siz * 'd', raw_data[i:i + dat_len])
+            self.y = struct.unpack(unicode('<' + dat_siz * 'd').encode('utf8'), raw_data[:dat_len])
+            self.x = struct.unpack(unicode('<' + dat_siz * 'd').encode('utf8'), raw_data[i:i + dat_len])
 
         else:
             print("File type %s not supported yet. Please add issue. "

--- a/spc/sub.py
+++ b/spc/sub.py
@@ -69,7 +69,7 @@ class subFile:
             x_dat_pos = y_dat_pos
             x_dat_end = x_dat_pos + (4 * pts)
 
-            x_raw = np.array(struct.unpack(x_str, data[x_dat_pos:x_dat_end]))
+            x_raw = np.array(struct.unpack(unicode(x_str).encode('utf8'), data[x_dat_pos:x_dat_end]))
             self.x = (2**(exp - 32)) * x_raw
 
             y_dat_pos = x_dat_end
@@ -82,7 +82,7 @@ class subFile:
             # Floating y-values
             y_dat_str += 'f' * pts
             y_dat_end = y_dat_pos + (4 * pts)
-            y_raw = np.array(struct.unpack(y_dat_str, data[y_dat_pos:y_dat_end]))
+            y_raw = np.array(struct.unpack(unicode(y_dat_str).encode('utf8'), data[y_dat_pos:y_dat_end]))
             self.y = y_raw
         else:
             # integer format
@@ -91,7 +91,7 @@ class subFile:
                 # 16 bit
                 y_dat_str += 'h' * pts  # short
                 y_dat_end = y_dat_pos + (2 * pts)
-                y_raw = np.array(struct.unpack(y_dat_str, data[y_dat_pos:y_dat_end]))
+                y_raw = np.array(struct.unpack(unicode(y_dat_str).encode('utf8'), data[y_dat_pos:y_dat_end]))
                 self.y = (2**(exp - 16)) * y_raw
             else:
                 # 32 bit, using size of subheader to figure out data type
@@ -99,7 +99,7 @@ class subFile:
                 # self.tsprec
                 y_dat_str += 'i' * pts
                 y_dat_end = y_dat_pos + (4 * pts)
-                y_raw = np.array(struct.unpack(y_dat_str, data[y_dat_pos:y_dat_end]))
+                y_raw = np.array(struct.unpack(unicode(y_dat_str).encode('utf8'), data[y_dat_pos:y_dat_end]))
                 self.y = (2**(exp - 32)) * y_raw
 
 
@@ -155,7 +155,7 @@ class subFileOld:
             x_dat_pos = y_dat_pos
             x_dat_end = x_dat_pos + (4 * pts)
 
-            x_raw = np.array(struct.unpack(x_str, data[x_dat_pos:x_dat_end]))
+            x_raw = np.array(struct.unpack(unicode(x_str).encode('utf8'), data[x_dat_pos:x_dat_end]))
             self.x = (2**(exp - 32)) * x_raw
 
             y_dat_pos = x_dat_end
@@ -169,14 +169,14 @@ class subFileOld:
         if yfloat:
             # floats are pretty straigtfoward
             y_dat_str = '<' + 'f' * pts
-            y_raw = struct.unpack(y_dat_str, data[y_dat_pos:y_dat_end])
+            y_raw = struct.unpack(unicode(y_dat_str).encode('utf8'), data[y_dat_pos:y_dat_end])
             self.y = y_raw
         else:
             # for old format, extract the entire array out as 1 bit unsigned
             # integers, swap 1st and 2nd byte, as well as 3rd and 4th byte to get
             # the final integer then scale by the exponent
             y_dat_str = '>' + 'B' * 4 * pts
-            y_raw = struct.unpack(y_dat_str, data[y_dat_pos:y_dat_end])
+            y_raw = struct.unpack(unicode(y_dat_str).encode('utf8'), data[y_dat_pos:y_dat_end])
 
             y_int = []
             for i in range(0, len(y_raw), 4):


### PR DESCRIPTION
Dear rohanisaac,

Thank you for making such a nice and helpful python module. I guess I have found a bug to fix in the recent Python 2.7.6, Mac OSX Yosemite 10.10.2:
Python returned `error: TypeError: Struct() argument 1 must be string, not unicode.` when running the spc module for converting *.spc files into *.csv or *.txt.
The method `unpack` of the python Struct() class seems to require a string variable in the first input. This pull request enables this module to handle the first input properly. I'd be happy if you can accept this pull request.

Best regards,
sshojiro