### PR TITLE
MAINT avoid importing spc before install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python
 
+import os
+
 from distutils.core import setup
 
-import spc
+ver_file = os.path.join('spc', '_version.py')
+with open(ver_file) as f:
+    exec(f.read())
 
 setup(name='spc',
-      version=spc.__version__,
-      description=spc.__doc__,
-      author=spc.__author__,
-      author_email=spc.__author_email__,
+      version=__version__,
+      description=__doc__,
+      author=__author__,
+      author_email=__author_email__,
       url='https://github.com/rohanisaac/spc',
       packages=['spc'],
       install_requires=['numpy'],

--- a/spc/__init__.py
+++ b/spc/__init__.py
@@ -3,8 +3,3 @@ Module for reading, exploring and converting SPC spectroscopic binary data in Py
 """
 
 from .spc import File
-
-__author__ = "Rohan Isaac"
-__author_email__ = "rohan_isaac@yahoo.com"
-__version__ = "0.4.0"
-__license__ = "GPLv3"

--- a/spc/_version.py
+++ b/spc/_version.py
@@ -1,0 +1,4 @@
+__author__ = "Rohan Isaac"
+__author_email__ = "rohan_isaac@yahoo.com"
+__version__ = "0.4.0"
+__license__ = "GPLv3"


### PR DESCRIPTION
Importing setup `spc` can lead to some issue. It will require numpy at build time (you actually only need it at run time).

This fix is actually parsing the _version.py to avoid importing the package itself. It is actually an usual way to do (https://github.com/uwescience/shablona).